### PR TITLE
Added args/props support to Gradient Texture story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ Thumbs.db
 
 # Local Netlify folder
 .netlify
+/.vs
+/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,3 @@ Thumbs.db
 
 # Local Netlify folder
 .netlify
-/.vs
-/package-lock.json

--- a/libs/soba/src/abstractions/gradient-texture.stories.ts
+++ b/libs/soba/src/abstractions/gradient-texture.stories.ts
@@ -3,7 +3,7 @@ import { NgtPlaneGeometryModule } from '@angular-three/core/geometries';
 import { NgtMeshBasicMaterialModule } from '@angular-three/core/materials';
 import { NgtMeshModule } from '@angular-three/core/meshes';
 import { NgtSobaGradientTextureModule } from '@angular-three/soba/abstractions';
-import { componentWrapperDecorator, Meta, moduleMetadata } from '@storybook/angular';
+import { componentWrapperDecorator, Meta, moduleMetadata, Story } from '@storybook/angular';
 import { setupCanvas, setupCanvasModules } from '../setup-canvas';
 
 export default {
@@ -23,13 +23,19 @@ export default {
   ],
 } as Meta;
 
-export const Default = () => ({
+export const Default: Story = (args) => ({
+  props: args,
   template: `
         <ngt-mesh>
             <ngt-plane-geometry></ngt-plane-geometry>
             <ngt-mesh-basic-material [depthWrite]="false" [side]="'double' | side">
-                <ngt-soba-gradient-texture [stops]="[0, 1]" [colors]='["aquamarine", "hotpink"]'></ngt-soba-gradient-texture>
+                <ngt-soba-gradient-texture [stops]="stops" [colors]="colors"></ngt-soba-gradient-texture>
             </ngt-mesh-basic-material>
         </ngt-mesh>
     `,
 });
+
+Default.args = {
+    stops: [0, 1],
+    colors: ['aquamarine', 'hotpink'],
+};


### PR DESCRIPTION
I've figure out enough to run the story book documentation.  This is a simple test for submitting my first pull request.

I noticed when trying to add a 3rd stop and color for gradient texture, I got the following error.  
![image](https://user-images.githubusercontent.com/25032599/167017239-e382ed7e-a730-41a5-aa57-2731ae8c7142.png)

Is this worth fixing?  Using the storybook, its not possible to add a new stop and color at the same time.