### PR TITLE
docs(core): fixed typo in ngt-primitive component

### DIFF
--- a/libs/documentations/docs/core/objects.mdx
+++ b/libs/documentations/docs/core/objects.mdx
@@ -144,8 +144,8 @@ More often than not, we want load 3D models from an external source and put them
   selector: 'some',
   template: `
     <ng-container *ngIf="model$ | async as model">
-                    <!-- 👇 NgtPrimitive exposes this object instead of itself like a NgtMesh -->
-      <ngt-primitive [object]="model.scene"></ng-primitive>
+      <!-- 👇 NgtPrimitive exposes this object instead of itself like a NgtMesh -->
+      <ngt-primitive [object]="model.scene"></ngt-primitive>
     </ng-container>
   `,
 })


### PR DESCRIPTION
I have changed a typo in <ngt-primitive [object]="model.scene"></ngt-primitive> because the letter 't' was missing at the end of the tag component.

This is my first PR into an OS project, so I apologize for any mistakes I may have made. I have been using this amazing library for two weeks and it has made my job a lot easier so I hope to contribute more often.

Thanks for all the work!